### PR TITLE
Do not override options when calling as_json.

### DIFF
--- a/book/models_and_collections/associations.asc
+++ b/book/models_and_collections/associations.asc
@@ -21,7 +21,8 @@ class Task < ActiveRecord::Base
   belongs_to :user
 
   def as_json(options = {})
-    super(include: { user: { only: [:name, :email] } })
+    # Merge options so you can still use @task.to_json(method: [:some_method]) for example
+    super(options.deep_merge(include: { user: { only: [:name, :email] } }))
   end
 end
 source~~~~


### PR DESCRIPTION
Merge options in models instead of overriding them, that way you can pass options from your controller.
