### PR TITLE
need to initialize empty bindings array otherwise call to this.bindings.p

### DIFF
--- a/book/views_and_templates/cleaning_up.asc
+++ b/book/views_and_templates/cleaning_up.asc
@@ -115,6 +115,7 @@ single call to +unbindFromAll()+ to unbind them:
 source~~~~
 var SomeCollectionView = Backbone.View.extend({
   initialize: function() {
+    this.bindings = [];
     this.bindTo(this.collection, "change", this.render);
   },
 


### PR DESCRIPTION
need to initialize empty bindings array otherwise call to this.bindings.push() will raise an error in bindTo()
