### PR TITLE
Composite view version of TaskDetail extending wrong class.

### DIFF
--- a/book/views_and_templates/composite_views.asc
+++ b/book/views_and_templates/composite_views.asc
@@ -126,7 +126,7 @@ Making use of +CompositeView+, we split up the +TaskDetail+ view class:
 
 [javascript]
 source~~~~
-var TaskDetail = Backbone.View.extend({
+var TaskDetail = CompositeView.extend({
   tagName: 'section',
   id: 'task',
 


### PR DESCRIPTION
The new implementation of TaskDetail should be extending CompositeView not Backbone.View.
