### PR TITLE
restore spies after example_app tests so they don't cause problems with later tests

### DIFF
--- a/example_app/spec/javascripts/example_app_spec.js
+++ b/example_app/spec/javascripts/example_app_spec.js
@@ -32,15 +32,21 @@ describe("ExampleApp", function(){
     });
 
     it("instantiates a Tasks router", function() {
-      ExampleApp.Routers.Tasks = sinon.spy();
+      sinon.spy(ExampleApp.Routers, 'Tasks');
       ExampleApp.initialize({});
       expect(ExampleApp.Routers.Tasks).toHaveBeenCalled();
+      ExampleApp.Routers.Tasks.restore();
     });
 
     it("starts Backbone.history", function() {
-      Backbone.history = { start: sinon.spy() };
+      Backbone.history.started = null;
+      Backbone.history.stop();
+      sinon.spy(Backbone.history, 'start');
       ExampleApp.initialize({});
+
       expect(Backbone.history.start).toHaveBeenCalled();
+
+      Backbone.history.start.restore();
     });
   });
 });


### PR DESCRIPTION
The way these tests are coded now can cause really nasty problems further down the line, as I experienced. In the first test, the Tasks router is being replaced by the spy, and it stays that way after the test is done.

The second test does the same for Backbone.history. In fact the second test only works because the first one overrides the router -- if you remove the "instantiates the Tasks router" test you'll find that the second test fails.

The fix here restores both spies after the tests are done, which I think is the right way to do this.
