### PR TITLE
file organization: remove reference to csrf patch

### DIFF
--- a/book/rails_integration/file_organization.md
+++ b/book/rails_integration/file_organization.md
@@ -179,8 +179,7 @@ them in your application.js Sprockets manifest:
 ````
 
 Load order for Backbone and your Backbone app is very
-important. jQuery and Underscore must be loaded before Backbone, then
-the Rails authenticity token patch must be applied. Then your models must be
+important. jQuery and Underscore must be loaded before Backbone. Then your models must be
 loaded before your collections (because your collections will reference your
 models) and then your routers and views must be loaded.
 


### PR DESCRIPTION
The authenticity token patch was apparently obviated by jquery_ujs, and hasn't been part of the example app for ~4 months. So no need to talk about it in terms of load order.

See also 297980c and 12cf52b.
